### PR TITLE
Stepping up Camel-Kura Quickstart to latest baseline.

### DIFF
--- a/kura-camel/pom.xml
+++ b/kura-camel/pom.xml
@@ -17,6 +17,9 @@
     </licenses>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    
         <!-- Kura Java runtime version is 7. -->
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
@@ -40,11 +43,11 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.eclipse.kura</groupId>
-            <artifactId>org.eclipse.kura.camel</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
-        </dependency>
+		<dependency>
+			<groupId>io.rhiot</groupId>
+			<artifactId>camel-kura</artifactId>
+			<version>${rhiot.version}</version>
+		</dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.api</artifactId>
@@ -102,8 +105,8 @@
     <repositories>
         <repository>
             <!-- We need this for the latest Rhiot SNAPSHOTs. -->
-            <id>sonatype.snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>eclipse.snapshots</id>
+            <url>https://repo.eclipse.org/content/repositories/kura-snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>

--- a/kura-camel/src/main/java/io/rhiot/quickstarts/kura/camel/GatewayRouter.java
+++ b/kura-camel/src/main/java/io/rhiot/quickstarts/kura/camel/GatewayRouter.java
@@ -1,23 +1,23 @@
 package io.rhiot.quickstarts.kura.camel;
 
+import java.util.Random;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.eclipse.kura.camel.camelcloud.DefaultCamelCloudService;
-import org.eclipse.kura.camel.cloud.KuraCloudComponent;
-import org.eclipse.kura.camel.router.CamelRouter;
 import org.eclipse.kura.message.KuraPayload;
 
-import java.util.Random;
+import io.rhiot.component.kura.cloud.KuraCloudComponent;
+import io.rhiot.component.kura.router.RhiotKuraRouter;
 
 /**
  * Example of the Kura Camel application.
  */
-public class GatewayRouter extends CamelRouter {
+public class GatewayRouter extends RhiotKuraRouter {
 
     @Override
     public void configure() throws Exception {
         KuraCloudComponent cloudComponent = new KuraCloudComponent();
-        cloudComponent.setCloudService(new DefaultCamelCloudService(camelContext));
+        cloudComponent.setCamelContext(camelContext);
         camelContext.addComponent("kura-cloud", cloudComponent);
 
         from("timer://heartbeat").


### PR DESCRIPTION
1. Updating repository location for Kura artifacts.
2. Stepping up dependencies to io.rhiot/camel-kura from org.eclipse.kura.camel
3. Stepping up GatewayRouter to RhiotKuraRouter from CamelRouter
4. Setting Camel Context for CloudComponent instead of obsolete setCloudService
